### PR TITLE
Support custom build directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ jobs:
       uses: shalzz/zola-deploy-action@master
       env:
         PAGES_BRANCH: master
+        PAGES_BRANCH: docs
         TOKEN: ${{ secrets.TOKEN }}
 ```
 
@@ -36,6 +37,7 @@ jobs:
 
 ## Environment Variables
 * `PAGES_BRANCH`: The git branch of your repo to which the built static files will be pushed. Default is `master` branch
+* `BUILD_DIR`: The zola build directory. Default is `.` (current directory)
 
 ## Custom Domain
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
       uses: shalzz/zola-deploy-action@master
       env:
         PAGES_BRANCH: master
-        PAGES_BRANCH: docs
+        BUILD_DIR: docs
         TOKEN: ${{ secrets.TOKEN }}
 ```
 
@@ -37,7 +37,7 @@ jobs:
 
 ## Environment Variables
 * `PAGES_BRANCH`: The git branch of your repo to which the built static files will be pushed. Default is `master` branch
-* `BUILD_DIR`: The zola build directory. Default is `.` (current directory)
+* `BUILD_DIR`: The path from the root of the repo where we should run the `zola build` command. Default is `.` (current directory)
 
 ## Custom Domain
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,10 @@ if [[ -z "$PAGES_BRANCH" ]]; then
     PAGES_BRANCH="master"
 fi
 
+if [[ -z "$DIRECTORY" ]]; then
+    DIRECTORY="."
+fi
+
 if [[ -z "$GITHUB_TOKEN" ]]; then
     echo "Set the GITHUB_TOKEN env variable."
     exit 1
@@ -34,6 +38,8 @@ main() {
 
     echo "Using $version"
 
+    cd $DIRECTORY
+    
     zola build
 
     echo "Pushing artifacts to ${GITHUB_REPOSITORY}:$remote_branch"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,8 +10,8 @@ if [[ -z "$PAGES_BRANCH" ]]; then
     PAGES_BRANCH="master"
 fi
 
-if [[ -z "$DIRECTORY" ]]; then
-    DIRECTORY="."
+if [[ -z "$BUILD_DIR" ]]; then
+    BUILD_DIR="."
 fi
 
 if [[ -z "$GITHUB_TOKEN" ]]; then
@@ -38,7 +38,7 @@ main() {
 
     echo "Using $version"
 
-    cd $DIRECTORY
+    cd $BUILD_DIR
     
     zola build
 


### PR DESCRIPTION
This PR can enable the user to build a custom directory by using env `BUILD_DIR`:
```yml
on: push
name: Build and deploy on push
jobs:
  build:
    name: shalzz/zola-deploy-action
    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@master
    - name: shalzz/zola-deploy-action
      uses: shalzz/zola-deploy-action@master
      env:
        PAGES_BRANCH: master
        BUILD_DIR: docs
        TOKEN: ${{ secrets.TOKEN }}
```