### PR TITLE
Add Ability to Pass Multiple Parameters to `zola build`

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ jobs:
 * `BUILD_DIR`: The path from the root of the repo where we should run the `zola build` command. Default is `.` (current directory)
 * `BUILD_FLAGS`: Custom build flags that you want to pass to zola while building. (Be careful supplying a different build output directory might break the action).
 * `BUILD_ONLY`: Set to value `true` if you don't want to deploy after `zola build`.
+* `BUILD_THEMES`: Set to false to disable fetching themes submodules. Default `true`.
 
 ## Custom Domain
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,7 +48,8 @@ main() {
     cd $BUILD_DIR
 
     echo Building with flags: ${BUILD_FLAGS:+"$BUILD_FLAGS"}
-    zola build ${BUILD_FLAGS:+"$BUILD_FLAGS"}
+    ARR_FLAGS=($(echo $BUILD_FLAGS | tr " " "\n"))
+    zola build "${ARR_FLAGS[@]}"
 
     if ${BUILD_ONLY}; then
         echo "Build complete. Deployment skipped by request"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,8 +52,7 @@ main() {
     cd $BUILD_DIR
 
     echo Building with flags: ${BUILD_FLAGS:+"$BUILD_FLAGS"}
-    ARR_FLAGS=($(echo $BUILD_FLAGS | tr " " "\n"))
-    zola build "${ARR_FLAGS[@]}"
+    zola build ${BUILD_FLAGS:+$BUILD_FLAGS}
 
     if ${BUILD_ONLY}; then
         echo "Build complete. Deployment skipped by request"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,10 +31,12 @@ fi
 main() {
     echo "Starting deploy..."
 
-    echo "Fetching themes"
     git config --global url."https://".insteadOf git://
     git config --global url."https://github.com/".insteadOf git@github.com:
-    git submodule update --init --recursive
+    if [[ -z "$BUILD_NO_THEMES" ]]; then
+        echo "Fetching themes"
+        git submodule update --init --recursive
+    fi
 
     version=$(zola --version)
     remote_repo="https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
@@ -44,7 +46,7 @@ main() {
 
     echo "Building in $BUILD_DIR directory"
     cd $BUILD_DIR
-    
+
     echo Building with flags: ${BUILD_FLAGS:+"$BUILD_FLAGS"}
     zola build ${BUILD_FLAGS:+"$BUILD_FLAGS"}
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,12 +28,16 @@ if [[ -z "$BUILD_ONLY" ]]; then
     BUILD_ONLY=false
 fi
 
+if [[ -z "$BUILD_THEMES" ]]; then
+    BUILD_THEMES=true
+fi
+
 main() {
     echo "Starting deploy..."
 
     git config --global url."https://".insteadOf git://
     git config --global url."https://github.com/".insteadOf git@github.com:
-    if [[ -z "$BUILD_NO_THEMES" ]]; then
+    if [[ "$BUILD_THEMES" ]]; then
         echo "Fetching themes"
         git submodule update --init --recursive
     fi


### PR DESCRIPTION
I was unable to pass multiple parameters to `zola build`, so I changed the entrypoint to create an array, based on space-separated parameters.

I also wanted to be able to avoid the themes submodule pull, so if defined, the environment variable `BUILD_NO_THEMES` will do that.