### PR TITLE
add support for cross-repo deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,12 @@ jobs:
 
 ## Environment Variables
 * `PAGES_BRANCH`: The git branch of your repo to which the built static files will be pushed. Default is `gh-pages` branch
+* `REPOSITORY`: The target repository to push to. Default is `GITHUB_REPOSITORY`(current repository). Set this variable if you want to deploy to other repo.
 * `BUILD_DIR`: The path from the root of the repo where we should run the `zola build` command. Default is `.` (current directory)
 * `BUILD_FLAGS`: Custom build flags that you want to pass to zola while building. (Be careful supplying a different build output directory might break the action).
 * `BUILD_ONLY`: Set to value `true` if you don't want to deploy after `zola build`.
 * `BUILD_THEMES`: Set to false to disable fetching themes submodules. Default `true`.
+
 
 ## Custom Domain
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,9 +14,14 @@ if [[ -z "$BUILD_DIR" ]]; then
     BUILD_DIR="."
 fi
 
-if [[ -z "$GITHUB_REPOSITORY" ]]; then
-    echo "Set the GITHUB_REPOSITORY env variable."
-    exit 1
+if [[ -n "$REPOSITORY" ]]; then
+    TARGET_REPOSITORY=$REPOSITORY
+else
+    if [[ -z "$GITHUB_REPOSITORY" ]]; then
+        echo "Set the GITHUB_REPOSITORY env variable."
+        exit 1
+    fi
+    TARGET_REPOSITORY=${GITHUB_REPOSITORY}
 fi
 
 if [[ -z "$BUILD_ONLY" ]]; then
@@ -43,7 +48,7 @@ main() {
     fi
 
     version=$(zola --version)
-    remote_repo="https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+    remote_repo="https://${GITHUB_TOKEN}@github.com/${TARGET_REPOSITORY}.git"
     remote_branch=$PAGES_BRANCH
 
     echo "Using $version"
@@ -57,8 +62,8 @@ main() {
     if ${BUILD_ONLY}; then
         echo "Build complete. Deployment skipped by request"
         exit 0
-    else 
-        echo "Pushing artifacts to ${GITHUB_REPOSITORY}:$remote_branch"
+    else
+        echo "Pushing artifacts to ${TARGET_REPOSITORY}:$remote_branch"
 
         cd public
         git init
@@ -66,7 +71,7 @@ main() {
         git config user.email "github-actions-bot@users.noreply.github.com"
         git add .
 
-        git commit -m "Deploy ${GITHUB_REPOSITORY} to ${GITHUB_REPOSITORY}:$remote_branch"
+        git commit -m "Deploy ${TARGET_REPOSITORY} to ${TARGET_REPOSITORY}:$remote_branch"
         git push --force "${remote_repo}" master:${remote_branch}
 
         echo "Deploy complete"


### PR DESCRIPTION
Add support for cross-repo deployment

**Why**

While blogging, users might need to separate their source repo and production repo.
In my case, I keep my original content separated in a private repository (`ianre657/my-zola-blog`), and the actual content would be pushed to my personal Github pages.

```
+ ianre657/my-zola-blog (source, private)
+ ianre657/ianre657.gthub.io (target, public)
```

As a reference, this kind of content management is the default scheme for Hexo
+ [hexo-deployer-git][hexo]

[hexo]: https://github.com/hexojs/hexo-deployer-git