### PR TITLE
[feature]: Add support for Github Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ jobs:
 * `BUILD_FLAGS`: Custom build flags that you want to pass to zola while building. (Be careful supplying a different build output directory might break the action).
 * `BUILD_ONLY`: Set to value `true` if you don't want to deploy after `zola build`.
 * `BUILD_THEMES`: Set to false to disable fetching themes submodules. Default `true`.
+* `GITHUB_HOSTNAME`: The Github hostname to use in your action. This is to account for Enterprise instances where the base URL differs from the default, which is `github.com`.
 
 
 ## Custom Domain

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,18 +37,23 @@ if [[ -z "$GITHUB_TOKEN" ]] && [[ "$BUILD_ONLY" == false ]]; then
     exit 1
 fi
 
+if [[ -z "$GITHUB_HOSTNAME" ]]; then
+    GITHUB_HOSTNAME="github.com"
+fi
+
 main() {
     echo "Starting deploy..."
 
     git config --global url."https://".insteadOf git://
-    git config --global url."https://github.com/".insteadOf git@github.com:
+    ## $GITHUB_SERVER_URL is set as a default environment variable in all workflows, default is https://github.com
+    git config --global url."$GITHUB_SERVER_URL/".insteadOf "git@${GITHUB_HOSTNAME}":
     if [[ "$BUILD_THEMES" ]]; then
         echo "Fetching themes"
         git submodule update --init --recursive
     fi
 
     version=$(zola --version)
-    remote_repo="https://${GITHUB_TOKEN}@github.com/${TARGET_REPOSITORY}.git"
+    remote_repo="https://${GITHUB_TOKEN}@${GITHUB_HOSTNAME}/${TARGET_REPOSITORY}.git"
     remote_branch=$PAGES_BRANCH
 
     echo "Using $version"
@@ -68,7 +73,7 @@ main() {
         cd public
         git init
         git config user.name "GitHub Actions"
-        git config user.email "github-actions-bot@users.noreply.github.com"
+        git config user.email "github-actions-bot@users.noreply.${GITHUB_HOSTNAME}"
         git add .
 
         git commit -m "Deploy ${TARGET_REPOSITORY} to ${TARGET_REPOSITORY}:$remote_branch"


### PR DESCRIPTION
This PR adds the `GITHUB_HOSTNAME` environment variable to the `entrypoint.sh` script to account for managed Github instances with different `hostname` values than the default `github.com` value.

It also leverages the `GITHUB_SERVER_URL` to define the `global.url` in git configs as it is already a [default environment variable](https://docs.github.com/en/actions/reference/environment-variables) offered in every workflow. In cases of public github that's `https://github.com`. In managed instances that's whatever the full URL is as is set by the self-hosted runner.

While in most cases you could probably use the `GITHUB_SERVER_URL` to parse out a `GITHUB_HOSTNAME`, there are some edge cases that could potentially cause problems with that approach, namely that it's not _required_ that Enterprise users set a hostname at all and [could conceivably use a hard-coded IP address](https://docs.github.com/en/enterprise-server@3.0/admin/configuration/configuring-a-hostname) (though that's ill-advised). 

Asking that the hostname be provided, if relevant, avoids needlessly complex `regex` to account for subdomains, IPs, http/https protocols and the possibility of breakage down the line if there were to be a backwards-incompatible update to whatever tool (`sed`, `awk`, etc.) were to be used in the latest debian image that's pulled as part of the build for this action.

I've tested this out on our Enterprise instance and can confirm that it works

```
    - name: 'build and deploy'
      uses: kathleenfrench/zola-deploy-action@feature-git-enterprise-support
      env:
        GITHUB_HOSTNAME: [redacted]
```

Happy to make any changes you'd like to see!

-k