### PR TITLE
Add the possibility to check links

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,3 +24,26 @@ jobs:
         BUILD_ONLY: true
         BUILD_DIR: test-site
         BUILD_FLAGS: --drafts --base-url example.com
+  build-3:
+    name: Build with CHECK_LINKS
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Build with the latest action rev
+      uses: shalzz/zola-deploy-action@master
+      env:
+        BUILD_ONLY: true
+        BUILD_DIR: test-site
+        CHECK_LINKS: true
+  build-4:
+    name: Build with CHECK_LINKS and CHECK_FLAGS
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Build with the latest action rev
+      uses: shalzz/zola-deploy-action@master
+      env:
+        BUILD_ONLY: true
+        BUILD_DIR: test-site
+        CHECK_LINKS: true
+        CHECK_FLAGS: --drafts

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ jobs:
 * `BUILD_FLAGS`: Custom build flags that you want to pass to zola while building. (Be careful supplying a different build output directory might break the action).
 * `BUILD_ONLY`: Set to value `true` if you don't want to deploy after `zola build`.
 * `BUILD_THEMES`: Set to false to disable fetching themes submodules. Default `true`.
+* `CHECK_LINKS`: Set to `true` to check links with `zola check`.
+* `CHECK_FLAGS`: Custom check flags that you want to pass to `zola check`.
 * `GITHUB_HOSTNAME`: The Github hostname to use in your action. This is to account for Enterprise instances where the base URL differs from the default, which is `github.com`.
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,6 +33,10 @@ if [[ -z "$BUILD_THEMES" ]]; then
     BUILD_THEMES=true
 fi
 
+if [[ -z "$CHECK_LINKS" ]]; then
+    CHECK_LINKS=false
+fi
+
 if [[ -z "$GITHUB_TOKEN" ]] && [[ "$BUILD_ONLY" == false ]]; then
     echo "Set the GITHUB_TOKEN or TOKEN env variables."
     exit 1
@@ -64,6 +68,11 @@ main() {
 
     echo Building with flags: ${BUILD_FLAGS:+"$BUILD_FLAGS"}
     zola build ${BUILD_FLAGS:+$BUILD_FLAGS}
+
+    if ${CHECK_LINKS}; then
+        echo "Checking links with flags: ${CHECK_FLAGS:+$CHECK_FLAGS}"
+        zola check ${CHECK_FLAGS:+$CHECK_FLAGS}
+    fi
 
     if ${BUILD_ONLY}; then
         echo "Build complete. Deployment skipped by request"


### PR DESCRIPTION
This PR introduces the possibility to check links with `zola check` by adding two environment variables: `CHECK_LINKS` and `CHECK_FLAGS`.

Similarly to `BUILD_ONLY` and `BUILD_FLAGS`, those two environment variables allow to trigger the use of `zola check` when running the GitHub Action and specify flags to be passed to the command, like `--drafts`.