### PR TITLE
Remove GITHUB_TOKEN from build job env

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ jobs:
           BUILD_DIR: docs
           BUILD_ONLY: true
           BUILD_FLAGS: --drafts
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           
   build_and_deploy:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ jobs:
           BUILD_DIR: docs
           BUILD_ONLY: true
           BUILD_FLAGS: --drafts
+          # A GitHub token is not necessary when BUILD_ONLY is true
+          # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           
   build_and_deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I believe that this isn't necessary, since we're building and not deploying.

Thanks for this great project!