### PR TITLE
Update entrypoint.sh to add safe.directory

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,6 +56,7 @@ main() {
     git config --global url."https://".insteadOf git://
     ## $GITHUB_SERVER_URL is set as a default environment variable in all workflows, default is https://github.com
     git config --global url."$GITHUB_SERVER_URL/".insteadOf "git@${GITHUB_HOSTNAME}":
+    git config --global --add safe.directory /github/workspace
     if [[ "$BUILD_THEMES" ]]; then
         echo "Fetching themes"
         git submodule update --init --recursive


### PR DESCRIPTION
When I use this action for my website, the job failed with `fatal: detected dubious ownership in repository at '/github/workspace'`, see https://github.com/NightsWatchGames/nightswatchgames.github.io/actions/runs/4040309510.

I added command `git config --global --add safe.directory /github/workspace` to entrypoint.sh and it works.