### PR TITLE
Reset safe directory permissions before fetching theme submodules

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,6 +56,7 @@ main() {
     git config --global url."https://".insteadOf git://
     ## $GITHUB_SERVER_URL is set as a default environment variable in all workflows, default is https://github.com
     git config --global url."$GITHUB_SERVER_URL/".insteadOf "git@${GITHUB_HOSTNAME}":
+    git config --global --add safe.directory "*"
     if [[ "$BUILD_THEMES" ]]; then
         echo "Fetching themes"
         git submodule update --init --recursive


### PR DESCRIPTION
Fixes shalzz/zola-deploy-action#50

I found in testing that simply specifying "/github/workspace" as in #51 was not sufficient for situations where additional submodules were fetched, so this PR supplies permissions for all directories instead.