### PR TITLE
bug fix: `BUILD_THEMES: false` doesn't work

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,7 +57,7 @@ main() {
     ## $GITHUB_SERVER_URL is set as a default environment variable in all workflows, default is https://github.com
     git config --global url."$GITHUB_SERVER_URL/".insteadOf "git@${GITHUB_HOSTNAME}":
     git config --global --add safe.directory "*"
-    if [[ "$BUILD_THEMES" ]]; then
+    if ${BUILD_THEMES}; then
         echo "Fetching themes"
         git submodule update --init --recursive
     fi


### PR DESCRIPTION
`[[ "$BUILD_THEMES" ]]` evaluates to `true` if `BUILD_THEME` is set to any value (whether it is `true` or `false`). It only evaluates to `false` if `$BUILD_THEME` is unset. Since earlier in the code `BUILD_THEMES` is set to `true` if it is unset, this means that the themes always get  built. 

[see this gist for example](https://gist.github.com/jxlxx/21cb78525ef9f0e391d044111b1a7b3b)
