### PR TITLE
Improve fix and add another env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ jobs:
 * `CHECK_LINKS`: Set to `true` to check links with `zola check`.
 * `CHECK_FLAGS`: Custom check flags that you want to pass to `zola check`.
 * `GITHUB_HOSTNAME`: The Github hostname to use in your action. This is to account for Enterprise instances where the base URL differs from the default, which is `github.com`.
+* `PULL_BRANCH_NAME`: The branch from which the source code is fetched, usually `main` (or on older repos `master`).
 
 
 ## Custom Domain

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@
 A GitHub action to automatically build and deploy your [zola] site to the master
 branch as GitHub Pages.
 
+## UPDATE: v0.16.1-2
+
+A new environment variable has been added. It's called `PULL_BRANCH_NAME`. If
+you're using `main` as your source code branch, you don't have to specify it.
+If you're source code branch is `master` then you are required to specify that
+in this new version.
+
 ## Table of Contents
 
  - [Usage](#usage)
@@ -89,7 +96,7 @@ jobs:
 * `CHECK_LINKS`: Set to `true` to check links with `zola check`.
 * `CHECK_FLAGS`: Custom check flags that you want to pass to `zola check`.
 * `GITHUB_HOSTNAME`: The Github hostname to use in your action. This is to account for Enterprise instances where the base URL differs from the default, which is `github.com`.
-* `PULL_BRANCH_NAME`: The branch from which the source code is fetched, usually `main` (or on older repos `master`).
+* `PULL_BRANCH_NAME`: The branch from which the source code is fetched, usually `main` (or on older repos `master`). Default `main`.
 
 
 ## Custom Domain

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,6 +63,10 @@ main() {
 
     echo "Setting default branch to #{DEFAULT_GIT_BRANCH_NAME}"
     git config --global init.defaultBranch $DEFAULT_GIT_BRANCH_NAME
+    echo "Disable some warnings"
+    git config --global --add safe.directory /github/workspace
+    git config --global --add safe.directory /github/workspace/themes/*
+
     if [[ "$BUILD_THEMES" ]]; then
         echo "Fetching themes"
         git submodule update --init --recursive

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -97,12 +97,17 @@ main() {
 
         cd "${OUT_DIR}"
         git init
+        echo "Init success"
         git config user.name "GitHub Actions"
         git config user.email "github-actions-bot@users.noreply.${GITHUB_HOSTNAME}"
+        echo "Configured git success"
         git add .
+        echo "Git add success"
 
         git commit -m "Deploy ${TARGET_REPOSITORY} to ${TARGET_REPOSITORY}:$remote_branch"
+        echo "Git commit success"
         git push --force "${remote_repo}" "${DEFAULT_GIT_BRANCH_NAME}:${remote_branch}"
+        echo "Git push success"
 
         echo "Deploy complete"
     fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,10 @@ if [[ -z "$PAGES_BRANCH" ]]; then
     PAGES_BRANCH="gh-pages"
 fi
 
+if [[ -z "$DEFAULT_GIT_BRANCH_NAME" ]]; then
+    DEFAULT_GIT_BRANCH_NAME="main"
+fi
+
 if [[ -z "$BUILD_DIR" ]]; then
     BUILD_DIR="."
 fi
@@ -56,6 +60,9 @@ main() {
     git config --global url."https://".insteadOf git://
     ## $GITHUB_SERVER_URL is set as a default environment variable in all workflows, default is https://github.com
     git config --global url."$GITHUB_SERVER_URL/".insteadOf "git@${GITHUB_HOSTNAME}":
+
+    echo "Setting default branch to #{DEFAULT_GIT_BRANCH_NAME}"
+    git config --global init.defaultBranch $DEFAULT_GIT_BRANCH_NAME
     if [[ "$BUILD_THEMES" ]]; then
         echo "Fetching themes"
         git submodule update --init --recursive
@@ -91,7 +98,7 @@ main() {
         git add .
 
         git commit -m "Deploy ${TARGET_REPOSITORY} to ${TARGET_REPOSITORY}:$remote_branch"
-        git push --force "${remote_repo}" master:"${remote_branch}"
+        git push --force "${remote_repo}" "${DEFAULT_GIT_BRANCH_NAME}:${remote_branch}"
 
         echo "Deploy complete"
     fi


### PR DESCRIPTION
This PR improves the fix of the workflow by further refining the configuration of git. Instead of setting all directories as safe directories with 

```
git config --global --add safe.directory "*"
```

it only adds the needed directories and lists them explicitly.

---

Additionally this PR fixes the same thing as #48 , but in a configurable way. The `PULL_BRANCH_NAME` can now be specified as another environment variable. For newer repos, it defaults to `main`, hence I chose that default value. If you are using `master` as your source code branch, you have to explicitly specify that. Now that I'm explaining that, I should probably add an additional note in the README...