### PR TITLE
Move `cd $BUILD_DIR` up to accomodate repo checkouts in subdirectory.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,6 +53,9 @@ fi
 main() {
     echo "Starting deploy..."
 
+    echo "Building in $BUILD_DIR directory"
+    cd "$BUILD_DIR"
+
     git config --global url."https://".insteadOf git://
     ## $GITHUB_SERVER_URL is set as a default environment variable in all workflows, default is https://github.com
     git config --global url."$GITHUB_SERVER_URL/".insteadOf "git@${GITHUB_HOSTNAME}":
@@ -67,9 +70,6 @@ main() {
     remote_branch=$PAGES_BRANCH
 
     echo "Using $version"
-
-    echo "Building in $BUILD_DIR directory"
-    cd "$BUILD_DIR"
 
     echo Building with flags: ${BUILD_FLAGS:+"$BUILD_FLAGS"}
     zola build ${BUILD_FLAGS:+$BUILD_FLAGS}


### PR DESCRIPTION
Follow up from #60, this allows a github action workflow that clones a repository to `subdir` to work.

I've also tested the case where a repository is cloned to the current directory, that running `git submodule update --init --recursive` in a subdirectory works:

```bash
# /tmp/abc2 is the repository
# /tmp/abc2/themes/juice is the submodule
cd /tmp/abc2/subdir
git submodule update --init --recursive
```

output:

```bash
Submodule 'themes/juice' (https://github.com/huhu/juice) registered for path '../themes/juice'
Cloning into '/tmp/abc2/themes/juice'...
Submodule path '../themes/juice': checked out '7466e194e139e00e5e002cd943ec52373eb3d1d0'
```