### PR TITLE
Add .nojekyll

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -91,6 +91,9 @@ main() {
         echo "Pushing artifacts to ${TARGET_REPOSITORY}:$remote_branch"
 
         cd "${OUT_DIR}"
+        
+        touch .nojekyll
+        
         git init
         git config user.name "GitHub Actions"
         git config user.email "github-actions-bot@users.noreply.${GITHUB_HOSTNAME}"


### PR DESCRIPTION
This adds a `.nojekyll` file when pushing the built site in order for git not to build it on jekyll, thus gaining performance.

Closes #66 