### PR TITLE
Update to zola 0.17.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV LANGUAGE en_US.UTF-8
 RUN apt-get update && apt-get install -y wget git
 
 RUN wget -q -O - \
-"https://github.com/getzola/zola/releases/download/v0.17.0/zola-v0.17.0-x86_64-unknown-linux-gnu.tar.gz" \
+"https://github.com/getzola/zola/releases/download/v0.17.1/zola-v0.17.1-x86_64-unknown-linux-gnu.tar.gz" \
 | tar xzf - -C /usr/local/bin
 
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jobs:
     - name: Checkout main
       uses: actions/checkout@v3.0.0
     - name: Build and deploy
-      uses: shalzz/zola-deploy-action@v0.17.0
+      uses: shalzz/zola-deploy-action@v0.17.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -58,7 +58,7 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@v3.0.0
       - name: Build only 
-        uses: shalzz/zola-deploy-action@v0.17.0
+        uses: shalzz/zola-deploy-action@v0.17.1
         env:
           BUILD_DIR: docs
           BUILD_ONLY: true
@@ -73,7 +73,7 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@v3.0.0
       - name: Build and deploy
-        uses: shalzz/zola-deploy-action@v0.17.0
+        uses: shalzz/zola-deploy-action@v0.17.1
         env:
           BUILD_DIR: docs
           PAGES_BRANCH: gh-pages


### PR DESCRIPTION
`0.17.0 ` introduced a bug that prevented sites from building if there is more than one `index.md` file in any folder in the content section. `0.17.1` fixes this issue. 