### PR TITLE
Fix "wrong number of arguments, should be 2" error

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,10 +61,15 @@ main() {
     git config --global url."$GITHUB_SERVER_URL/".insteadOf "git@${GITHUB_HOSTNAME}":
 
     # needed or else we get 'doubious ...' error
-    echo "Set safe directories"
+    echo "Set safe directories:"
+    echo " - /github/workspace"
     git config --global --add safe.directory /github/workspace
-    git config --global --add safe.directory /github/workspace/sass/**/*
-    git config --global --add safe.directory /github/workspace/themes/*
+    echo " - /github/workspace/sass/"
+    git config --global --add safe.directory /github/workspace/sass/
+    echo " - /github/workspace/themes/"
+    git config --global --add safe.directory /github/workspace/themes/
+    
+    echo
 
     if ${BUILD_THEMES}; then
         echo "Fetching themes"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -62,12 +62,14 @@ main() {
 
     # needed or else we get 'doubious ...' error
     echo "Set safe directories:"
-    echo " - /github/workspace"
-    git config --global --add safe.directory /github/workspace
-    echo " - /github/workspace/sass/"
-    git config --global --add safe.directory /github/workspace/sass/
-    echo " - /github/workspace/themes/"
-    git config --global --add safe.directory /github/workspace/themes/
+    git config --global --add safe.directory '*'
+    
+   #echo " - /github/workspace"
+   #git config --global --add safe.directory /github/workspace
+   #echo " - /github/workspace/sass/"
+   #git config --global --add safe.directory '/github/workspace/sass/*'
+   #echo " - /github/workspace/themes/"
+   #git config --global --add safe.directory '/github/workspace/themes/*'
     
     echo
 


### PR DESCRIPTION
Fix for #71. The error seems to be caused by the star-signs in the paths to `sass` and `themes` folders. Removing them seems to fix the issue [on my repository's workflow](https://github.com/Kosmorro/website/actions/runs/4587959384/jobs/8101857687), _which does not use any submodule_.

**This contribution should be tested** against websites that use submodules to validate it fixes the issue for them too, and does not break anything. To test this contribution, edit your workflow and replace the `uses` value with this branch:

```diff
      - name: Build and deploy
-        uses: shalzz/zola-deploy-action@v0.17.2
+        uses: Deuchnord/zola-deploy-action@fix/safe-directory
        env:
          PAGES_BRANCH: gh-pages
          TOKEN: ${{ secrets.TOKEN }}
```

I have taken this opportunity to add more logs on this part to make it easier to debug if something goes wrong later.