### PR TITLE
suppress default branch name warning

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,6 +64,8 @@ main() {
     echo "Disable safe directory check"
     git config --global --add safe.directory '*'
 
+    git config --global init.defaultBranch 'gh_action' # avoid warning re. default branch name change
+
     if ${BUILD_THEMES}; then
         echo "Fetching themes"
         git submodule update --init --recursive
@@ -96,7 +98,7 @@ main() {
         git add .
 
         git commit -m "Deploy ${TARGET_REPOSITORY} to ${TARGET_REPOSITORY}:$remote_branch"
-        git push --force "${remote_repo}" master:"${remote_branch}"
+        git push --force "${remote_repo}" gh_action:"${remote_branch}"
 
         echo "Deploy complete"
     fi


### PR DESCRIPTION
Github actions warn you when you use the default git init with the default branch name as it may change in the future, but you have `master` hardcoded later, so changing defaults will break the workflow

I've added an explicit name so that even when the default changes, that won't break the workflow

Picked a less common `gh_action` name as the previous `master` confused me when trying a few options, I thought it was bugged because my site's repo's branch was `main` (I realized later that the branch name is irrelevant, a non master/main name would've helped, so I picked one here)