### PR TITLE
Update version of checkout used in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout main
-      uses: actions/checkout@v3.0.0
+      uses: actions/checkout@v4
     - name: Build and deploy
       uses: shalzz/zola-deploy-action@v0.17.2
       env:
@@ -56,7 +56,7 @@ jobs:
     if: github.ref != 'refs/heads/main'
     steps:
       - name: Checkout main
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v4
       - name: Build only 
         uses: shalzz/zola-deploy-action@v0.17.2
         env:
@@ -71,7 +71,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout main
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v4
       - name: Build and deploy
         uses: shalzz/zola-deploy-action@v0.17.2
         env:


### PR DESCRIPTION
I think it would be a good idea to update to the new version of checkout in the example. The current example is pinned to a very old version of checkout. I also just pinned it to version 4 instead of 4.0.0 so the documentation doesn't require updates as often to be up to date. That's also how they show it in the example in [their readme](https://github.com/actions/checkout#usage).