### PR TITLE
Upgrade to zola 0.18.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV LANGUAGE en_US.UTF-8
 RUN apt-get update && apt-get install -y wget git
 
 RUN wget -q -O - \
-"https://github.com/getzola/zola/releases/download/v0.17.2/zola-v0.17.2-x86_64-unknown-linux-gnu.tar.gz" \
+"https://github.com/getzola/zola/releases/download/v0.18.0/zola-v0.18.0-x86_64-unknown-linux-gnu.tar.gz" \
 | tar xzf - -C /usr/local/bin
 
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jobs:
     - name: Checkout main
       uses: actions/checkout@v4
     - name: Build and deploy
-      uses: shalzz/zola-deploy-action@v0.17.2-1
+      uses: shalzz/zola-deploy-action@v0.18.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -58,7 +58,7 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@v4
       - name: Build only 
-        uses: shalzz/zola-deploy-action@v0.17.2-1
+        uses: shalzz/zola-deploy-action@v0.18.0
         env:
           BUILD_DIR: docs
           BUILD_ONLY: true
@@ -73,7 +73,7 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@v4
       - name: Build and deploy
-        uses: shalzz/zola-deploy-action@v0.17.2-1
+        uses: shalzz/zola-deploy-action@v0.18.0
         env:
           BUILD_DIR: docs
           PAGES_BRANCH: gh-pages


### PR DESCRIPTION
- Upgrade zola to 0.18.0
- Bump action version in examples (should be correct after tag/release)