### PR TITLE
create .nojekyll file in OUT_DIR

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -90,6 +90,9 @@ main() {
         echo "Pushing artifacts to ${TARGET_REPOSITORY}:$remote_branch"
 
         cd "${OUT_DIR}"
+
+        touch .nojekyll
+
         git init
         git config user.name "GitHub Actions"
         git config user.email "github-actions-bot@users.noreply.${GITHUB_HOSTNAME}"


### PR DESCRIPTION
It tells GitHub this is not a Jekyll site. This way GitHub does not attempt to build it with Jekyll resulting in faster deployments.

**UPD Clarification:** GitHub needs this file to be in the branch that is being deployed. The file in the `main`/`master` branch does not matter. I tested it.

- Without `.nojekyll` on `gh-pages` branch: https://github.com/eugene-babichenko/eugene-babichenko.github.io/actions/runs/9696325529/job/26758000824
- With it: https://github.com/eugene-babichenko/eugene-babichenko.github.io/actions/runs/9696774002/job/26759419116